### PR TITLE
feat: hide chunk number from OLED status line

### DIFF
--- a/Code/PocketMage_V3/src/APP_TEMPLATE.cpp
+++ b/Code/PocketMage_V3/src/APP_TEMPLATE.cpp
@@ -569,8 +569,7 @@ static void updateOLED() {
     if ((int)title.length() > 36) title = title.substring(0, 35) + "~";
     u8g2.drawStr(1, 9, title.c_str());
 
-    String info = "Pg " + String((unsigned long)(pageIndex + 1)) + "/" + String(maxPg + 1) +
-                  "  Ck " + String(currentChunk + 1) + "/" + String(totalCk);
+    String info = "Pg " + String((unsigned long)(pageIndex + 1)) + "/" + String(maxPg + 1);
     u8g2.drawStr(1, 20, info.c_str());
 
     u8g2.drawFrame(0, 25, 256, 7);


### PR DESCRIPTION
## Summary
- Remove the "Ck N/M" segment from the reading-mode OLED info line
- The progress bar already reflects global book position; chunk numbers are an implementation detail
- OLED now shows only "Pg X/Y"

## Test plan
- [ ] Build and flash; open a multi-chunk book
- [ ] Confirm OLED shows "Pg X/Y" with no chunk counter
- [ ] Navigate to a chunk boundary and confirm OLED still updates correctly

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>